### PR TITLE
6 グループ選択ドロップダウンの選択状態を永続化

### DIFF
--- a/src/components/LotteryPanel.tsx
+++ b/src/components/LotteryPanel.tsx
@@ -63,7 +63,9 @@ export default function LotteryPanel() {
         try {
           const parsed = JSON.parse(savedState);
           savedId = parsed.selectedClassId || null;
-        } catch {}
+        } catch (e) {
+          console.warn("localStorageのパースに失敗しました:", e);
+        }
       }
       // savedIdが有効なクラスIDなら使う、そうでなければ最初のクラスを選ぶ
       const validId = data.some((c) => c.id === savedId)

--- a/src/components/LotteryPanel.tsx
+++ b/src/components/LotteryPanel.tsx
@@ -14,6 +14,7 @@ import { drawRandom, drawRoundRobin } from "../lottery-logic";
 export default function LotteryPanel() {
   const [classes, setClasses] = useState<Class[]>([]);
   const [selectedClassId, setSelectedClassId] = useState<number | null>(null);
+
   const [mode, setMode] = useState<"random-no-save" | "round-robin">(
     "round-robin",
   );
@@ -25,6 +26,8 @@ export default function LotteryPanel() {
 
   const timerRef = useRef<number | null>(null);
   const finalizeTimerRef = useRef<number | null>(null);
+
+  const localStorageKey = "Lottery-App";
 
   useEffect(() => {
     loadClasses();
@@ -53,9 +56,18 @@ export default function LotteryPanel() {
     try {
       const data = await lotteryDB.getAllClasses();
       setClasses(data);
-      if (data.length > 0 && !selectedClassId) {
-        setSelectedClassId(data[0].id);
+      // localStorageから保存されているIDを読み込む
+      const savedState = localStorage.getItem(localStorageKey);
+      let savedId: number | null = null;
+      if (savedState) {
+        try {
+          const parsed = JSON.parse(savedState);
+          savedId = parsed.selectedClassId || null;
+        } catch {}
       }
+      // savedIdが有効なクラスIDなら使う、そうでなければ最初のクラスを選ぶ
+      const validId = data.some((c) => c.id === savedId) ? savedId : (data.length > 0 ? data[0].id : null);
+      setSelectedClassId(validId);
     } catch (error) {
       console.error("クラスの読み込みに失敗しました:", error);
     }
@@ -75,6 +87,10 @@ export default function LotteryPanel() {
     if (selectedClassId) {
       loadNominations(selectedClassId);
       setResult(null);
+      localStorage.setItem(
+        localStorageKey,
+        JSON.stringify({ selectedClassId }),
+      );
     }
   }, [selectedClassId]);
 
@@ -152,7 +168,9 @@ export default function LotteryPanel() {
             value={selectedClassId || ""}
             onChange={(e) => {
               const val = e.target.value;
-              setSelectedClassId(val ? Number(val) : null);
+              const newId = val ? Number(val) : null;
+              setSelectedClassId(newId);
+              localStorage.setItem(localStorageKey, JSON.stringify({ selectedClassId: newId }));
             }}
             className="w-full px-4 py-3 rounded-xl border border-slate-200 focus:ring-4 focus:ring-indigo-100 focus:border-indigo-600 outline-none transition-all font-medium text-slate-900 bg-slate-50"
           >

--- a/src/components/LotteryPanel.tsx
+++ b/src/components/LotteryPanel.tsx
@@ -66,7 +66,11 @@ export default function LotteryPanel() {
         } catch {}
       }
       // savedIdが有効なクラスIDなら使う、そうでなければ最初のクラスを選ぶ
-      const validId = data.some((c) => c.id === savedId) ? savedId : (data.length > 0 ? data[0].id : null);
+      const validId = data.some((c) => c.id === savedId)
+        ? savedId
+        : data.length > 0
+          ? data[0].id
+          : null;
       setSelectedClassId(validId);
     } catch (error) {
       console.error("クラスの読み込みに失敗しました:", error);
@@ -170,7 +174,6 @@ export default function LotteryPanel() {
               const val = e.target.value;
               const newId = val ? Number(val) : null;
               setSelectedClassId(newId);
-              localStorage.setItem(localStorageKey, JSON.stringify({ selectedClassId: newId }));
             }}
             className="w-full px-4 py-3 rounded-xl border border-slate-200 focus:ring-4 focus:ring-indigo-100 focus:border-indigo-600 outline-none transition-all font-medium text-slate-900 bg-slate-50"
           >

--- a/src/components/ManagePanel.tsx
+++ b/src/components/ManagePanel.tsx
@@ -99,7 +99,12 @@ export default function ManagePanel() {
       alert("保存しました");
     } catch (error) {
       console.error("保存に失敗しました:", error);
-      alert("保存中にエラーが発生しました");
+      // ConstraintError の場合は別のメッセージを表示
+      if (error instanceof Error && error.name === "ConstraintError") {
+        alert("テーブル名を変更してください");
+      } else {
+        alert("保存中にエラーが発生しました");
+      }
     } finally {
       setIsSaving(false);
     }

--- a/src/components/ManagePanel.tsx
+++ b/src/components/ManagePanel.tsx
@@ -101,7 +101,7 @@ export default function ManagePanel() {
       console.error("保存に失敗しました:", error);
       // ConstraintError の場合は別のメッセージを表示
       if (error instanceof Error && error.name === "ConstraintError") {
-        alert("テーブル名を変更してください");
+        alert("クラス名が既に存在します。別のクラス名を入力してください");
       } else {
         alert("保存中にエラーが発生しました");
       }

--- a/src/lottery-db.ts
+++ b/src/lottery-db.ts
@@ -28,7 +28,7 @@
 // findNominationsByDate(date)	日付でノミネーションを検索
 
 const DB_NAME = "NominationToolDB";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE_CLASSES = "classes";
 const STORE_NOMINATIONS = "nominations";
 

--- a/src/lottery-db.ts
+++ b/src/lottery-db.ts
@@ -65,17 +65,24 @@ export async function openDB(): Promise<IDBDatabase> {
     // データベースのスキーマを作る / 更新するハンドラ
     req.onupgradeneeded = (event) => {
       const database = (event.target as IDBOpenDBRequest).result;
+      const transaction = (event.target as IDBOpenDBRequest).transaction!;
 
-      // object store 作成: "classes", "nominations"
-      // keyPath: "id" を指定するとオブジェクトの `id` プロパティがキーとして使われる
-      // autoIncrement: true にするとキーは自動的にインクリメントされる
+      let classStore: IDBObjectStore;
       if (!database.objectStoreNames.contains(STORE_CLASSES)) {
-        const classStore = database.createObjectStore(STORE_CLASSES, {
+        classStore = database.createObjectStore(STORE_CLASSES, {
           keyPath: "id",
           autoIncrement: true,
         });
-        classStore.createIndex("name", "name", { unique: true });
+      } else {
+        classStore = transaction.objectStore(STORE_CLASSES);
       }
+
+      // v1 → v2 アップグレード時、既存のインデックスを削除して再作成
+      if (classStore.indexNames.contains("name")) {
+        classStore.deleteIndex("name");
+      }
+      classStore.createIndex("name", "name", { unique: true });
+
       if (!database.objectStoreNames.contains(STORE_NOMINATIONS)) {
         const nominationStore = database.createObjectStore(STORE_NOMINATIONS, {
           keyPath: "id",

--- a/src/lottery-db.ts
+++ b/src/lottery-db.ts
@@ -74,7 +74,7 @@ export async function openDB(): Promise<IDBDatabase> {
           keyPath: "id",
           autoIncrement: true,
         });
-        classStore.createIndex("name", "name", { unique: false });
+        classStore.createIndex("name", "name", { unique: true });
       }
       if (!database.objectStoreNames.contains(STORE_NOMINATIONS)) {
         const nominationStore = database.createObjectStore(STORE_NOMINATIONS, {

--- a/src/lottery-db.ts
+++ b/src/lottery-db.ts
@@ -1,6 +1,6 @@
 // IndexedDBを操作するモジュール
 // - データベース名: "NominationToolDB"
-// - バージョン: 1
+// - バージョン: 2
 // - オブジェクトストア:
 //   - "classes": { id, name, items(カンマ区切り文字列), createdAt, updatedAt }
 //   - "nominations": { id, classId, itemName, createdAt }
@@ -66,6 +66,7 @@ export async function openDB(): Promise<IDBDatabase> {
     req.onupgradeneeded = (event) => {
       const database = (event.target as IDBOpenDBRequest).result;
       const transaction = (event.target as IDBOpenDBRequest).transaction!;
+      const oldVersion = event.oldVersion;
 
       let classStore: IDBObjectStore;
       if (!database.objectStoreNames.contains(STORE_CLASSES)) {
@@ -73,15 +74,17 @@ export async function openDB(): Promise<IDBDatabase> {
           keyPath: "id",
           autoIncrement: true,
         });
+        // 新規作成時は最初からユニークインデックスを作成
+        classStore.createIndex("name", "name", { unique: true });
       } else {
         classStore = transaction.objectStore(STORE_CLASSES);
-      }
 
-      // v1 → v2 アップグレード時、既存のインデックスを削除して再作成
-      if (classStore.indexNames.contains("name")) {
-        classStore.deleteIndex("name");
+        // v1 → v2 アップグレード時、既存のインデックスを削除して再作成
+        if (oldVersion < 2 && classStore.indexNames.contains("name")) {
+          classStore.deleteIndex("name");
+          classStore.createIndex("name", "name", { unique: true });
+        }
       }
-      classStore.createIndex("name", "name", { unique: true });
 
       if (!database.objectStoreNames.contains(STORE_NOMINATIONS)) {
         const nominationStore = database.createObjectStore(STORE_NOMINATIONS, {


### PR DESCRIPTION
LocalStrageにSelectClassIDを保存することで、グループ選択ドロップダウンの選択状態を永続化
また、グループ名が重複する場合、新しく作れないようにしているのでふさわしいエラー文を表示するように変更した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * クラス選択がブラウザに保存され、次回読み込み時に前回の選択が復元されます

* **バグ修正**
  * 保存時のエラー表示を改善し、クラス名重複時は専用の警告を表示するようになりました
  * データベースの更新でクラス名の重複を防ぐ仕組みを導入し、データ整合性が向上しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->