### PR TITLE
✨抽選取り消しボタンの設置

### DIFF
--- a/src/components/LotteryPanel.tsx
+++ b/src/components/LotteryPanel.tsx
@@ -168,6 +168,15 @@ export default function LotteryPanel() {
     if (selectedClassId) {
       await loadNominations(selectedClassId);
     }
+    try {
+      await lotteryDB.deleteNomination(nominationId);
+      if (selectedClassId) {
+        await loadNominations(selectedClassId);
+      }
+    } catch (error) {
+      console.error("履歴の削除に失敗しました:", error);
+      alert("履歴の削除に失敗しました");
+    }
   };
 
   return (
@@ -401,6 +410,8 @@ export default function LotteryPanel() {
                   </span>
                   <button
                     onClick={() => handleRemoveFromHistory(nom.id)}
+                    disabled={isDrawing}
+                    aria-label={`「${nom.itemName}」を履歴から削除して未抽選状態に戻す`}
                     className="font-bold text-xs text-slate-400 hover:text-red-500 transition-colors"
                   >
                     X

--- a/src/components/LotteryPanel.tsx
+++ b/src/components/LotteryPanel.tsx
@@ -162,6 +162,14 @@ export default function LotteryPanel() {
     setResult(null);
   };
 
+  const handleRemoveFromHistory = async (nominationId: number) => {
+    if (!confirm("この学生を未抽選状態に戻します。よろしいですか？")) return;
+    await lotteryDB.deleteNomination(nominationId);
+    if (selectedClassId) {
+      await loadNominations(selectedClassId);
+    }
+  };
+
   return (
     <div className="max-w-5xl mx-auto p-6 bg-slate-50 min-h-screen space-y-6">
       {/* 1. 設定セクション (ManagePanel のヘッダースタイル) */}
@@ -391,6 +399,12 @@ export default function LotteryPanel() {
                   <span className="font-medium text-slate-700 text-sm">
                     {nom.itemName}
                   </span>
+                  <button
+                    onClick={() => handleRemoveFromHistory(nom.id)}
+                    className="font-bold text-xs text-slate-400 hover:text-red-500 transition-colors"
+                  >
+                    X
+                  </button>
                 </div>
               ))
             )}


### PR DESCRIPTION
# **要件**
- 当選履歴に表示されている学生ごとに「×ボタン（抽選取り消し）」を配置する。
- ×ボタン押下時、該当学生のみを当選履歴から削除する。
- 削除された学生は、抽選箱（未抽選リスト）に戻る。
- 他の当選履歴および抽選状態には影響を与えない。

#5 close

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ノミネーション履歴から項目を削除できるようになりました。各履歴項目に小さな削除ボタン（×）が追加され、クリックで確認ダイアログが表示され、削除後は履歴が自動的に更新されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->