### PR TITLE
11 ホームボタンを押下するとトップ画面に戻るようにしたい

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import ManagePanel from "./components/ManagePanel";
 import LotteryPanel from "./components/LotteryPanel";
 
@@ -12,6 +12,11 @@ import LotteryPanel from "./components/LotteryPanel";
  */
 export default function App() {
   const [activeTab, setActiveTab] = useState<"lottery" | "manage">("lottery");
+
+  // タブの切り替えごとにトップに戻す
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [activeTab]);
 
   return (
     <div className="min-h-screen bg-slate-50 font-sans text-slate-900">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import LotteryPanel from "./components/LotteryPanel";
 
 /**
  * App: アプリケーションのメインエントリーポイント
- * 
+ *
  * 機能:
  * - ナビゲーション（抽選 / クラス管理）
  * - 全体的なレイアウトテンプレート
@@ -19,14 +19,16 @@ export default function App() {
       <nav className="bg-white border-b border-slate-200 sticky top-0 z-50">
         <div className="max-w-6xl mx-auto px-4">
           <div className="flex justify-between items-center h-16">
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 bg-indigo-600 rounded-lg flex items-center justify-center text-white shadow-indigo-200 shadow-lg">
+            <button onClick={() => setActiveTab("lottery")}>
+              <div className="flex items-center gap-2">
+                <div className="w-8 h-8 bg-indigo-600 rounded-lg flex items-center justify-center text-white shadow-indigo-200 shadow-lg">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/></svg>
+                </div>
+                <span className="font-black text-xl tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 to-violet-600">
+                  LOTTERY APP
+                </span>
               </div>
-              <span className="font-black text-xl tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 to-violet-600">
-                LOTTERY APP
-              </span>
-            </div>
+            </button>
 
             <div className="flex gap-1 bg-slate-100 p-1 rounded-xl">
               <button

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,4 @@
 @import "tailwindcss";
+button {
+    cursor: pointer;
+}


### PR DESCRIPTION
# 関連イシュー
close #11 

#　変更箇所
- タイトルロゴからトップ画面(抽選画面)に戻れるように変更
- クリック可能であることが分かりやすいようにindex.cssの変更(buttonでカーソルがポインタになるように変更)
- タブ切り替え/ページ遷移の場合、常に一番上から表示されるように変更

# 変更箇所
App.tsx
index.css


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ロゴをクリックしてロトリーアプリに戻れるようになりました
  * タブ切り替え時に自動で画面トップにスクロールします

* **改善**
  * ボタンホバー時のカーソル表示を改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->