### PR TITLE
✨抽選中の操作を無効化

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import LotteryPanel from "./components/LotteryPanel";
  */
 export default function App() {
   const [activeTab, setActiveTab] = useState<"lottery" | "manage">("lottery");
+  const [isDrawing, setIsDrawing] = useState(false);
 
   // タブの切り替えごとにトップに戻す
   useEffect(() => {
@@ -40,21 +41,23 @@ export default function App() {
             <div className="flex gap-1 bg-slate-100 p-1 rounded-xl">
               <button
                 onClick={() => setActiveTab("lottery")}
+                disabled={isDrawing}
                 className={`px-6 py-2 rounded-lg text-sm font-bold transition-all ${
                   activeTab === "lottery"
                     ? "bg-white text-indigo-600 shadow-sm"
                     : "text-slate-500 hover:text-slate-700"
-                }`}
+                } disabled:opacity-50 disabled:cursor-not-allowed`}
               >
                 抽選
               </button>
               <button
                 onClick={() => setActiveTab("manage")}
+                disabled={isDrawing}
                 className={`px-6 py-2 rounded-lg text-sm font-bold transition-all ${
                   activeTab === "manage"
                     ? "bg-white text-indigo-600 shadow-sm"
                     : "text-slate-500 hover:text-slate-700"
-                }`}
+                } disabled:opacity-50 disabled:cursor-not-allowed`}
               >
                 グループ管理
               </button>
@@ -67,7 +70,7 @@ export default function App() {
       <main className="py-8">
         {activeTab === "lottery" ? (
           <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
-            <LotteryPanel />
+            <LotteryPanel isDrawing={isDrawing} setIsDrawing={setIsDrawing} />
           </div>
         ) : (
           <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">

--- a/src/components/LotteryPanel.tsx
+++ b/src/components/LotteryPanel.tsx
@@ -11,7 +11,16 @@ import { drawRandom, drawRoundRobin } from "../lottery-logic";
  * - 構造をシンプルに保ち、ユーザーが後から自由に書き換えられるように設計
  * - PC一画面での視認性を考慮したレイアウト
  */
-export default function LotteryPanel() {
+
+interface LotteryPanelProps {
+  isDrawing: boolean;
+  setIsDrawing: (value: boolean) => void;
+}
+
+export default function LotteryPanel({
+  isDrawing,
+  setIsDrawing,
+}: LotteryPanelProps) {
   const [groups, setGroups] = useState<Group[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
 
@@ -20,7 +29,6 @@ export default function LotteryPanel() {
   );
   const [result, setResult] = useState<string | null>(null);
   const [nominations, setNominations] = useState<Nominations[]>([]);
-  const [isDrawing, setIsDrawing] = useState(false);
   const [shuffleName, setShuffleName] = useState("");
   const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -202,7 +210,8 @@ export default function LotteryPanel() {
               const newId = val ? Number(val) : null;
               setSelectedGroupId(newId);
             }}
-            className="w-full px-4 py-3 rounded-xl border border-slate-200 focus:ring-4 focus:ring-indigo-100 focus:border-indigo-600 outline-none transition-all font-medium text-slate-900 bg-slate-50"
+            disabled={isDrawing}
+            className="w-full px-4 py-3 rounded-xl border border-slate-200 focus:ring-4 focus:ring-indigo-100 focus:border-indigo-600 outline-none transition-all font-medium text-slate-900 bg-slate-50 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {groups.map((group) => (
               <option key={group.id} value={group.id}>
@@ -215,21 +224,23 @@ export default function LotteryPanel() {
         <div className="flex bg-slate-100 p-1 rounded-xl items-center h-[52px]">
           <button
             onClick={() => setMode("random-no-save")}
+            disabled={isDrawing}
             className={`px-6 py-2.5 rounded-lg text-sm font-bold transition-all ${
               mode === "random-no-save"
                 ? "bg-white text-indigo-600 shadow-sm"
                 : "text-slate-500 hover:text-slate-700"
-            }`}
+            } disabled:opacity-50 disabled:cursor-not-allowed`}
           >
             ランダム
           </button>
           <button
             onClick={() => setMode("round-robin")}
+            disabled={isDrawing}
             className={`px-6 py-2.5 rounded-lg text-sm font-bold transition-all ${
               mode === "round-robin"
                 ? "bg-white text-indigo-600 shadow-sm"
                 : "text-slate-500 hover:text-slate-700"
-            }`}
+            } disabled:opacity-50 disabled:cursor-not-allowed`}
           >
             一巡モード
           </button>


### PR DESCRIPTION
# 実施した変更内容
1. App.tsx ✅
- isDrawing 状態を App.tsx に追加
- タブ切り替えボタン（抽選/グループ管理）に disabled={isDrawing} を追加
- ディセーブル時のスタイル（半透明 + カーソル不可）を追加
- isDrawing と setIsDrawing を LotteryPanel へプロップで受け渡し
2. LotteryPanel.tsx ✅
- インターフェース LotteryPanelProps を定義
- コンポーネントでプロップ { isDrawing, setIsDrawing } を受け取り
- ローカルの isDrawing 状態定義を削除
- グループ選択セレクトに disabled={isDrawing} を追加
- モード切り替えボタン（ランダム/一巡）に disabled={isDrawing} を追加
- ディセーブル時のスタイルクラスを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 抽選実行中のUI操作をより適切に制御。抽選中はタブボタンやグループ選択、モード切替ボタンが無効状態になり、ユーザー体験が向上しました。
  * 無効化されたボタンやセレクトボックスに視覚的フィードバック（透明度低下、カーソル変更）を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->